### PR TITLE
fix: retarget Codacy scan workflow to main, bump upload-sarif to v3

### DIFF
--- a/.github/workflows/codacy.yml
+++ b/.github/workflows/codacy.yml
@@ -15,10 +15,10 @@ name: Codacy Security Scan
 
 on:
   push:
-    branches: [ "master" ]
+    branches: [ "main" ]
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [ "master" ]
+    branches: [ "main" ]
   schedule:
     - cron: '41 21 * * 1'
 
@@ -56,6 +56,6 @@ jobs:
 
       # Upload the SARIF file generated in the previous step
       - name: Upload SARIF results file
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: results.sarif


### PR DESCRIPTION
codacy.yml only triggered on push/pull_request to \`master\`, so it never ran on PRs targeting \`main\` (#36 included) — that's why no checks ever reported. Also bumps the now-deprecated \`codeql-action/upload-sarif@v2\` to \`v3\`.

Follow-up: ruleset 9037178 requires a \`CodeQL\`-named tool for the code_scanning rule, but this workflow reports under Codacy's own tool names (Shellcheck, Remark-lint, Jacksonlinter) — real CodeQL doesn't cover this repo's content (shell/lua/yaml) anyway. Will update the ruleset separately to match reality.